### PR TITLE
Add mandatory status column to subscriptions table

### DIFF
--- a/migrations/20211109085543_add_status_to_subscriptions.sql
+++ b/migrations/20211109085543_add_status_to_subscriptions.sql
@@ -1,0 +1,2 @@
+-- Create an optional status column in the subscriptions table.
+ALTER TABLE subscriptions ADD COLUMN status TEXT NULL;

--- a/migrations/20211109092540_make_status_not_null_in_subscriptions.sql
+++ b/migrations/20211109092540_make_status_not_null_in_subscriptions.sql
@@ -1,0 +1,8 @@
+-- Mark status as not NULL
+-- Begin SQL transaction.
+BEGIN;
+  -- Change status from NULL to 'confirmed'
+  UPDATE subscriptions SET status = 'confirmed' WHERE status IS NULL;
+  -- Make status mandatory
+  ALTER TABLE subscriptions ALTER COLUMN status SET NOT NULL;
+COMMIT;

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,7 +1,7 @@
 {
   "db": "PostgreSQL",
-  "4a1c526df578752272a05ab0ced36ca13d96ac8aae0c2f60038e181831312065": {
-    "query": "\n    INSERT INTO subscriptions (id, email, name, subscribed_at)\n    VALUES ($1, $2, $3, $4)\n    ",
+  "fa7aebd9339b30891ff19198abc2b1dfd7520e027f0a148cc6b3f99dbd8a9d93": {
+    "query": "\n    INSERT INTO subscriptions (id, email, name, subscribed_at, status)\n    VALUES ($1, $2, $3, $4, $5)\n    ",
     "describe": {
       "columns": [],
       "parameters": {
@@ -9,7 +9,8 @@
           "Uuid",
           "Text",
           "Text",
-          "Timestamptz"
+          "Timestamptz",
+          "Text"
         ]
       },
       "nullable": []

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -49,13 +49,14 @@ pub async fn insert_subscriber(
 ) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
-    INSERT INTO subscriptions (id, email, name, subscribed_at)
-    VALUES ($1, $2, $3, $4)
+    INSERT INTO subscriptions (id, email, name, subscribed_at, status)
+    VALUES ($1, $2, $3, $4, $5)
     "#,
         Uuid::new_v4(),
         new_subscriber.email.as_ref(),
         new_subscriber.name.as_ref(),
-        Utc::now()
+        Utc::now(),
+        "confirmed"
     )
     .execute(pool)
     .await


### PR DESCRIPTION
Use zero downtime deployment.

Changes:
- ci: Create migration to add status column to subscriptions table
- refactor: Add subscriber to database with "confirmed" status
- ci: Create migration to backfill status with "confirmed" and make status mandatory
- ci: Re-run `cargo sqlx prepare`

